### PR TITLE
redishost and tls

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,21 +3,36 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 var (
-	RedisHost string
-	AIHost string
+	RedisHost  string
+	AIHost     string
+	TLSEnabled bool
 )
 
 func InitConfig() {
 	env := os.Getenv("ENVIRONMENT")
+	tlsEnv := os.Getenv("TLS_ENABLED")
+	tlsEnabled, err := strconv.ParseBool(tlsEnv)
+	if err != nil {
+		tlsEnabled = false
+	}
+	TLSEnabled = tlsEnabled
+
 	if env == "local" {
 		RedisHost = "localhost:6379"
+		TLSEnabled = false
 		AIHost = "localhost:8082"
 		fmt.Println("Running in local mode")
 	} else {
-		RedisHost = "redis:6379"
+		redisEnvHost := os.Getenv("REDIS_HOST")
+		if redisEnvHost != "" {
+			RedisHost = redisEnvHost
+		} else {
+			RedisHost = "redis:6379"
+		}
 		AIHost = "http://ai-service:8082"
 		fmt.Println("Running in Docker mode")
 	}

--- a/pkg/services/redis.go
+++ b/pkg/services/redis.go
@@ -1,11 +1,12 @@
 package services
 
 import (
+	"Learning-Mode-AI-quiz-service/pkg/config"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"time"
-    "Learning-Mode-AI-quiz-service/pkg/config"
 
 	"github.com/go-redis/redis/v8"
 )
@@ -16,47 +17,57 @@ var ctx = context.Background()
 var rdb *redis.Client
 
 func InitRedis(redisHost string, redisPassword string, redisDB int) {
+	var tlsConfig *tls.Config
+	if config.TLSEnabled {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	} else {
+		tlsConfig = nil
+	}
+
 	rdb = redis.NewClient(&redis.Options{
-		Addr:     config.RedisHost, // Replace with Redis server address
-		Password: "",               // If no password set
-		DB:       0,                // Use default DB
+		Addr:      config.RedisHost, // Replace with Redis server address
+		TLSConfig: tlsConfig,
 	})
+	err := rdb.Ping(ctx).Err()
+	if err != nil {
+		panic(err)
+	}
 }
 
 // StoreQuizInRedis stores a quiz in Redis with a specified TTL
 func StoreQuizInRedis(videoID string, quiz *AIResponse) error {
-    key := fmt.Sprintf("quiz:%s", videoID) // Use "quiz:<video_id>" as the key
-    data, err := json.Marshal(quiz)
-    if err != nil {
-        return fmt.Errorf("failed to marshal quiz data: %w", err)
-    }
+	key := fmt.Sprintf("quiz:%s", videoID) // Use "quiz:<video_id>" as the key
+	data, err := json.Marshal(quiz)
+	if err != nil {
+		return fmt.Errorf("failed to marshal quiz data: %w", err)
+	}
 
-    err = rdb.Set(ctx, key, data, 24*time.Hour).Err() // Store with a 24-hour TTL
-    if err != nil {
-        return fmt.Errorf("failed to store quiz in Redis: %w", err)
-    }
+	err = rdb.Set(ctx, key, data, 24*time.Hour).Err() // Store with a 24-hour TTL
+	if err != nil {
+		return fmt.Errorf("failed to store quiz in Redis: %w", err)
+	}
 
-    return nil
+	return nil
 }
-
 
 // GetQuizFromRedis fetches a quiz from Redis
 func GetQuizFromRedis(videoID string) (*AIResponse, error) {
-    key := fmt.Sprintf("quiz:%s", videoID) // Use "quiz:<video_id>" as the key
-    val, err := rdb.Get(ctx, key).Result()
-    if err == redis.Nil {
-        // Key does not exist
-        return nil, nil
-    } else if err != nil {
-        return nil, fmt.Errorf("failed to retrieve quiz from Redis: %w", err)
-    }
+	key := fmt.Sprintf("quiz:%s", videoID) // Use "quiz:<video_id>" as the key
+	val, err := rdb.Get(ctx, key).Result()
+	if err == redis.Nil {
+		// Key does not exist
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to retrieve quiz from Redis: %w", err)
+	}
 
-    var quiz AIResponse
-    err = json.Unmarshal([]byte(val), &quiz)
-    if err != nil {
-        return nil, fmt.Errorf("failed to unmarshal quiz data from Redis: %w", err)
-    }
+	var quiz AIResponse
+	err = json.Unmarshal([]byte(val), &quiz)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal quiz data from Redis: %w", err)
+	}
 
-    return &quiz, nil
+	return &quiz, nil
 }
-


### PR DESCRIPTION
All Redis-based services (main-backend, ai-service, snapshot-service) now use ElastiCache if redis_host is defined
config.go:
Updated RedisHost to dynamically fetch from the environment (REDIS_HOST).
Falls back to redis:6379 if not set.

redis_service.go:
Added TLS configuration to securely connect to ElastiCache.
Enabled InsecureSkipVerify: true to bypass cert validation (temporary).